### PR TITLE
Bump nippy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.1.2] - 2020-11-04
+### Security
+- Bump `com.taoensso/nippy` from `2.14.0` to `2.15.0` to fix
+[CVE-2020-24164](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-24164)
+
 ## [Unreleased]
 ### Changed
 - Add a new arity to `make-widget-async` to provide a different widget shape.

--- a/clj-nippy-serde.iml
+++ b/clj-nippy-serde.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module cursive.leiningen.project.LeiningenProjectsManager.displayName="clj-nippy-serde:0.1.0-SNAPSHOT" cursive.leiningen.project.LeiningenProjectsManager.isLeinModule="true" type="JAVA_MODULE" version="4">
+<module cursive.leiningen.project.LeiningenProjectsManager.displayName="clj-nippy-serde:0.1.2-SNAPSHOT" cursive.leiningen.project.LeiningenProjectsManager.isLeinModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/classes" />

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.kafka/kafka-clients "1.0.1" :exclusions [org.scala-lang/scala-library]]
                  [org.apache.kafka/kafka-streams "1.0.1"]
-                 [com.taoensso/nippy "2.14.0"]]
+                 [com.taoensso/nippy "2.15.0"]]
 
   :aot [clj-nippy-serde.serialization]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bigsy/clj-nippy-serde "0.1.0"
+(defproject bigsy/clj-nippy-serde "0.1.2"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
This bumps `com.taoensso/nippy` from 2.14.0 --> 2.15.0 which includes a fix for ["Deserialization of Untrusted Data"](https://app.snyk.io/vuln/SNYK-JAVA-COMTAOENSSO-674320)

I've only tested using `lein test`, which seemed to work. 