### PR TITLE
Bump nippy to support allowlist additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.1.3] - 2020-11-10
+### Security
+- Bump `com.taoensso/nippy` from `2.15.0` to `2.15.3` to allow adding classes
+to `*serializable-whitelist*` via
+[JVM properties or env vars](https://github.com/ptaoussanis/nippy/blob/79e78f1e51704f2236163175405e862eac9594b5/CHANGELOG.md#v2151--2020-aug-27)
+
+
 ## [0.1.2] - 2020-11-04
 ### Security
 - Bump `com.taoensso/nippy` from `2.14.0` to `2.15.0` to fix

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bigsy/clj-nippy-serde "0.1.2"
+(defproject bigsy/clj-nippy-serde "0.1.3"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.kafka/kafka-clients "1.0.1" :exclusions [org.scala-lang/scala-library]]
                  [org.apache.kafka/kafka-streams "1.0.1"]
-                 [com.taoensso/nippy "2.15.0"]]
+                 [com.taoensso/nippy "2.15.3"]]
 
   :aot [clj-nippy-serde.serialization]
 


### PR DESCRIPTION
nippy 2.15.0 fixed a CVE by introducing an allowlist for classes, so users could add any they trust.

It wasn't until [2.15.1](https://github.com/ptaoussanis/nippy/blob/79e78f1e51704f2236163175405e862eac9594b5/CHANGELOG.md#v2151--2020-aug-27) though that users can add their own classes to the allowlist via JVM options (or env vars). Some common classes were added to the default allowlist in 2.15.3, so I think it's worthwhile bumping to that version.

Users of `clj-nippy-serde` will need to be able to do this, we've already seen a use-case for this in the `contracts-api`, with the exception coming out of acceptance tests:

```
clojure.lang.ExceptionInfo: Unfreezable type: class org.joda.time.LocalDate
    as-str: "#object[org.joda.time.LocalDate 0xbbdca07 \"2020-11-09\"]"
      type: org.joda.time.LocalDate
```

@Bigsy if you're okay with this, I was wondering if we actually want to bump `clj-nippy-serde` to 0.2.0 instead of 0.1.3?